### PR TITLE
fix: added placeholder for missing item images

### DIFF
--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -50,7 +50,7 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image || '/placeholder.png'}
+                src={this.props.item.image || "/placeholder.png"}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "auto", width: "305px", borderRadius: "6px" }}

--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -50,10 +50,10 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image}
+                src={this.props.item.image || '/placeholder.png'}
                 alt={this.props.item.title}
                 className="item-img"
-                style={{ height: "500px", width: "100%", borderRadius: "6px" }}
+                style={{ height: "auto", width: "305px", borderRadius: "6px" }}
               />
             </div>
 

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image || '/placeholder.png'}
+        src={item.image || "/placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || '/placeholder.png'}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
Also adjusted styles for item detail images.

# Description

resolves #INC-5312: Missing image

<img width="494" alt="image" src="https://user-images.githubusercontent.com/2767295/191277263-e9ccb25d-bbe4-4a39-b5b9-100b24e4b7d3.png">
<img width="734" alt="image" src="https://user-images.githubusercontent.com/2767295/191277345-67dc66c1-d3b5-46ce-a29e-80a6fb15e8e3.png">
