### PR TITLE
fix: user info min-width problem

### DIFF
--- a/frontend/src/custom.scss
+++ b/frontend/src/custom.scss
@@ -57,5 +57,7 @@ body {
 }
 
 .user-info {
-  min-width: 800px;
+  @media screen and (min-width: 768px) {
+    min-width: 800px;
+  }
 }

--- a/frontend/src/custom.scss
+++ b/frontend/src/custom.scss
@@ -55,9 +55,3 @@ body {
   display: -webkit-box;
   -webkit-box-orient: vertical;
 }
-
-.user-info {
-  @media screen and (min-width: 768px) {
-    min-width: 800px;
-  }
-}


### PR DESCRIPTION
It should only apply on desktop

<img width="436" alt="image" src="https://user-images.githubusercontent.com/2767295/191876653-3ed8768d-1b89-4053-b1b6-e69558934110.png">

<img width="819" alt="image" src="https://user-images.githubusercontent.com/2767295/191876772-dda05839-819e-47ee-99d7-6590988d0815.png">

